### PR TITLE
Fix typo "algorythm" --> "algorithm"

### DIFF
--- a/source/locale.js
+++ b/source/locale.js
@@ -13,7 +13,7 @@
 //
 export default function chooseLocale(locales, isLocaleDataAvailable)
 {
-	// This is not an intelligent algorythm,
+	// This is not an intelligent algorithm,
 	// but it will do for this library's case.
 	// `sr-Cyrl-BA` -> `sr-Cyrl` -> `sr`.
 	for (let locale of locales) {


### PR DESCRIPTION
Noticed this typo in the comments and thought I'd propose a fix.