### PR TITLE
Add tiny support for Spanish

### DIFF
--- a/locale-more-styles/es/tiny.json
+++ b/locale-more-styles/es/tiny.json
@@ -1,0 +1,10 @@
+{
+	"year": "{0}año",
+	"month": "{0}mes",
+	"week": "{0}sem.",
+	"day": "{0}d",
+	"hour": "{0}h",
+	"minute": "{0}m",
+	"second": "{0}s",
+	"now": "ahora"
+}

--- a/locale/es/index.js
+++ b/locale/es/index.js
@@ -9,5 +9,5 @@ module.exports = {
 	// Additional styles.
 	'tiny': require('../../locale-more-styles/es/tiny.json'),
 	// Quantifier.
-	quantify: locale.quantify,
+	quantify: locale.quantify
 }

--- a/locale/es/index.js
+++ b/locale/es/index.js
@@ -7,5 +7,6 @@ module.exports = {
 	short: locale.short,
 	narrow: locale.narrow,
 	// Quantifier.
-	quantify: locale.quantify
+	quantify: locale.quantify,
+	'tiny': require('../../locale-more-styles/es/tiny.json'),
 }

--- a/locale/es/index.js
+++ b/locale/es/index.js
@@ -6,7 +6,8 @@ module.exports = {
 	long: locale.long,
 	short: locale.short,
 	narrow: locale.narrow,
+	// Additional styles.
+	'tiny': require('../../locale-more-styles/es/tiny.json'),
 	// Quantifier.
 	quantify: locale.quantify,
-	'tiny': require('../../locale-more-styles/es/tiny.json'),
 }


### PR DESCRIPTION
Created tiny.json under locale-more-styles/es and referenced the file in the es module export