### PR TITLE
Add long-time style for italian

### DIFF
--- a/locale-more-styles/it/long-time.json
+++ b/locale-more-styles/it/long-time.json
@@ -1,0 +1,34 @@
+{
+	"year": {
+		"one": "{0} anno",
+		"other": "{0} anni"
+	},
+	"month": {
+		"one": "{0} mese",
+		"other": "{0} mesi"
+	},
+	"week": {
+		"one": "{0} settimana",
+		"other": "{0} settimane"
+	},
+	"day": {
+		"one": "{0} giorno",
+		"other": "{0} giorni"
+	},
+	"hour": {
+		"one": "{0} ora",
+		"other": "{0} ore"
+	},
+	"minute": {
+		"one": "{0} minuto",
+		"other": "{0} minuti"
+	},
+	"second": {
+		"one": "{0} secondo",
+		"other": "{0} secondi"
+	},
+	"now": {
+		"future": "tra poco",
+		"past": "proprio ora"
+	}
+}

--- a/locale/it/index.js
+++ b/locale/it/index.js
@@ -6,6 +6,8 @@ module.exports = {
 	long: locale.long,
 	short: locale.short,
 	narrow: locale.narrow,
+	// Additional styles.
+	'long-time': require('../../locale-more-styles/it/long-time.json'),
 	// Quantifier.
 	quantify: locale.quantify
 }


### PR DESCRIPTION
This is meant to remove the italian 'fa' keyword as the english locale does with 'ago'.

In english:
"10 seconds ago" with long-time style results "10 seconds"

In italian:
"10 secondi fa" with long-time style will results "10 secondi"