### PR TITLE
Add some missing long time languages

### DIFF
--- a/locale-more-styles/da/long-time.json
+++ b/locale-more-styles/da/long-time.json
@@ -20,7 +20,7 @@
     "other": "{0} timer"
   },
   "minute": {
-    "one": "{0} minutter",
+    "one": "{0} minut",
     "other": "{0} minutter"
   },
   "second": {

--- a/locale-more-styles/da/long-time.json
+++ b/locale-more-styles/da/long-time.json
@@ -1,0 +1,34 @@
+{
+  "year": {
+    "one": "{0} år",
+    "other": "{0} år"
+  },
+  "month": {
+    "one": "{0} måned",
+    "other": "{0} måneder"
+  },
+  "week": {
+    "one": "{0} uge",
+    "other": "{0} uger"
+  },
+  "day": {
+    "one": "{0} dag",
+    "other": "{0} dage"
+  },
+  "hour": {
+    "one": "{0} time",
+    "other": "{0} timer"
+  },
+  "minute": {
+    "one": "{0} minutter",
+    "other": "{0} minutter"
+  },
+  "second": {
+    "one": "{0} sekund",
+    "other": "{0} sekunder"
+  },
+  "now": {
+    "future": "om et øjeblik",
+    "past": "lige nu"
+  }
+}

--- a/locale-more-styles/es/long-time.json
+++ b/locale-more-styles/es/long-time.json
@@ -1,0 +1,34 @@
+{
+    "year": {
+        "one": "{0} año",
+        "other": "{0} años"
+    },
+    "month": {
+        "one": "{0} mes",
+        "other": "{0} meses"
+    },
+    "week": {
+        "one": "{0} semana",
+        "other": "{0} semanas"
+    },
+    "day": {
+        "one": "{0} día",
+        "other": "{0} días"
+    },
+    "hour": {
+        "one": "{0} hora",
+        "other": "{0} horas"
+    },
+    "minute": {
+        "one": "{0} minuto",
+        "other": "{0} minutos"
+    },
+    "second": {
+        "one": "{0} segundo",
+        "other": "{0} segundos"
+    },
+    "now": {
+        "future": "enseguida",
+        "past": "ahora mismo"
+    }
+}

--- a/locale-more-styles/fr/long-time.json
+++ b/locale-more-styles/fr/long-time.json
@@ -1,0 +1,34 @@
+{
+    "year": {
+        "one": "{0} an",
+        "other": "{0} ans"
+    },
+    "month": {
+        "one": "{0} mois",
+        "other": "{0} mois"
+    },
+    "week": {
+        "one": "{0} semaine",
+        "other": "{0} semaines"
+    },
+    "day": {
+        "one": "{0} jour",
+        "other": "{0} jours"
+    },
+    "hour": {
+        "one": "{0} heure",
+        "other": "{0} heures"
+    },
+    "minute": {
+        "one": "{0} minute",
+        "other": "{0} minutes"
+    },
+    "second": {
+        "one": "{0} seconde",
+        "other": "{0} secondes"
+    },
+    "now": {
+        "future": "dans un instant",
+        "past": "à l'instant"
+    }
+}

--- a/locale-more-styles/nl/long-time.json
+++ b/locale-more-styles/nl/long-time.json
@@ -1,0 +1,34 @@
+{
+    "year": {
+        "one": "{0} jaar",
+        "other": "{0} jaar"
+    },
+    "month": {
+        "one": "{0} maand",
+        "other": "{0} maanden"
+    },
+    "week": {
+        "one": "{0} week",
+        "other": "{0} weken"
+    },
+    "day": {
+        "one": "{0} dag",
+        "other": "{0} dagen"
+    },
+    "hour": {
+        "one": "{0} uur",
+        "other": "{0} uur"
+    },
+    "minute": {
+        "one": "{0} minuut",
+        "other": "{0} minuten"
+    },
+    "second": {
+        "one": "{0} seconde",
+        "other": "{0} seconden"
+    },
+    "now": {
+        "future": "zometeen",
+        "past": "zojuist"
+    }
+}

--- a/locale-more-styles/sv/long-time.json
+++ b/locale-more-styles/sv/long-time.json
@@ -1,0 +1,34 @@
+{
+    "year": {
+        "one": "{0} år",
+        "other": "{0} år"
+    },
+    "month": {
+        "one": "{0} månad",
+        "other": "{0} månader"
+    },
+    "week": {
+        "one": "{0} vecka",
+        "other": "{0} veckor"
+    },
+    "day": {
+        "one": "{0} dag",
+        "other": "{0} dagar"
+    },
+    "hour": {
+        "one": "{0} timme",
+        "other": "{0} timmar"
+    },
+    "minute": {
+        "one": "{0} minut",
+        "other": "{0} minuter"
+    },
+    "second": {
+        "one": "{0} sekund",
+        "other": "{0} sekunder"
+    },
+    "now": {
+        "future": "om ett ögonblick",
+        "past": "alldeles nyss"
+    }
+}

--- a/locale/da/index.js
+++ b/locale/da/index.js
@@ -6,6 +6,8 @@ module.exports = {
 	long: locale.long,
 	short: locale.short,
 	narrow: locale.narrow,
+	// Additional styles.
+	'long-time': require('../../locale-more-styles/da/long-time.json'),
 	// Quantifier.
 	quantify: locale.quantify
 }

--- a/locale/es/index.js
+++ b/locale/es/index.js
@@ -8,6 +8,7 @@ module.exports = {
 	narrow: locale.narrow,
 	// Additional styles.
 	'tiny': require('../../locale-more-styles/es/tiny.json'),
+	'long-time': require('../../locale-more-styles/es/long-time.json'),
 	// Quantifier.
 	quantify: locale.quantify
 }

--- a/locale/fr/index.js
+++ b/locale/fr/index.js
@@ -6,6 +6,8 @@ module.exports = {
 	long: locale.long,
 	short: locale.short,
 	narrow: locale.narrow,
+	// Additional styles.
+	'long-time': require('../../locale-more-styles/fr/long-time.json'),
 	// Quantifier.
 	quantify: locale.quantify
 }

--- a/locale/nl/index.js
+++ b/locale/nl/index.js
@@ -6,6 +6,8 @@ module.exports = {
 	long: locale.long,
 	short: locale.short,
 	narrow: locale.narrow,
+	// Additional styles.
+	'long-time': require('../../locale-more-styles/nl/long-time.json'),
 	// Quantifier.
 	quantify: locale.quantify
 }

--- a/locale/sv/index.js
+++ b/locale/sv/index.js
@@ -6,6 +6,8 @@ module.exports = {
 	long: locale.long,
 	short: locale.short,
 	narrow: locale.narrow,
+	// Additional styles.
+	'long-time': require('../../locale-more-styles/sv/long-time.json'),
 	// Quantifier.
 	quantify: locale.quantify
 }


### PR DESCRIPTION
We're happily using javascript-time-ago in Trustpilot. We use a few languages that are not yet supported in long-time yet, however, and we asked our localization team to help us put this PR together. Let me know if you have any questions.